### PR TITLE
Implemented support for Claude API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ Dataset prep/*
 paz/*
 __pycache__/*
 
+test.py

--- a/Pre_processing.ipynb
+++ b/Pre_processing.ipynb
@@ -50,7 +50,7 @@
     "    with open(input_file, 'r') as infile, open(output_file, 'w', newline='') as outfile:\n",
     "        csv_writer = csv.writer(outfile)\n",
     "        \n",
-    "        header = ['time', 'emotion_1', 'emotion_2', 'emotion_3', 'emotion_4', 'emotion_5','emotion_6','emotion_7']\n",
+    "        header = ['time', 'Anger', 'Disgust', 'Fear', 'Happiness', 'Sadness','Surprise','Neutral']\n",
     "        csv_writer.writerow(header)\n",
     "        \n",
     "        for line in infile:\n",

--- a/gui.py
+++ b/gui.py
@@ -15,7 +15,7 @@ import math
 import cProfile
 import pstats
 
-from emili_core import time_since
+from emili_core_old_with_logging import time_since
 
 
 def create_chat_evaluation():

--- a/utils.py
+++ b/utils.py
@@ -2,9 +2,12 @@ import openai
 import requests
 import os
 import json
+import anthropic
+from anthropic.types import Message, TextBlock
 from tenacity import retry, wait_exponential, stop_after_attempt, retry_if_exception_type
 
 openai.api_key = os.environ["OPENAI_API_KEY"]
+anthropic.api_key = os.environ.get("ANTHROPIC_API_KEY")
 client = openai.OpenAI()
 
 # Most models return a response object: To recover the generated text, use 
@@ -45,7 +48,7 @@ def json_to_object(data):
     return json.loads(data, object_hook=JSONToObject)
 
 @retry(wait=wait_exponential(multiplier=1.5, min=1, max=60), stop=stop_after_attempt(6), retry=retry_if_exception_type(Exception))
-def get_api_response(messages, model="gpt-3.5-turbo", temperature=1.0, max_tokens=64, seed=1331, return_full_response=False):
+def get_OAI_api_response(messages, model="gpt-3.5-turbo", temperature=1.0, max_tokens=64, seed=1331, return_full_response=False):
     try:
         full_response = client.chat.completions.create(
             model=model,
@@ -61,10 +64,77 @@ def get_api_response(messages, model="gpt-3.5-turbo", temperature=1.0, max_token
         print(f"(API error: {e}, retrying...)")
         raise e
 
-def get_response(messages, model="gpt-3.5-turbo", temperature=1.0, max_tokens=64, seed=1331, return_full_response=False):
+
+
+def get_Claude_response(messages, model="claude-3-sonnet-20240229", temperature=1.0, max_tokens=1024, return_full_response=False):
+    try:
+        client = anthropic.Anthropic()
+
+        system_messages = []
+        api_messages = []
+
+        print("Debug: Processing input messages:")
+        for idx, message in enumerate(messages):
+            role = message['role']
+            content = message['content']
+
+            if role == 'system':
+                if isinstance(content, str):
+                    system_messages.append(content)
+                    print(f"Debug: Found text-based system message {idx+1}: {content[:50]}...")
+                else:
+                    print(f"Debug: Skipping non-text system message {idx+1}: {type(content)}")
+            else:
+                api_messages.append({"role": role, "content": content})
+                print(f"Debug: Added {role} message {idx+1} to API messages")
+
+        if model == "gpt-4-vision-preview": model = "claude-3-sonnet-20240229"
+        kwargs = {
+            "model": model,
+            "messages": api_messages,
+            "max_tokens": max_tokens,
+            "temperature": temperature
+        }
+
+        if system_messages:
+            kwargs["system"] = "\n".join(system_messages)
+            print(f"\nDebug: Using all system messages for API call. Total system message length: {len(kwargs['system'])}")
+        else:
+            print("\nDebug: No text-based system messages to send to API")
+
+        print("\nDebug: Preparing to make API call with the following parameters:")
+        print(f"  Model: {kwargs['model']}")
+        print(f"  Max tokens: {kwargs['max_tokens']}")
+        print(f"  Temperature: {kwargs['temperature']}")
+        print(f"  System message: {'Present' if 'system' in kwargs else 'Not present'}")
+        print(f"  Number of messages: {len(kwargs['messages'])}")
+
+        print("\nDebug: Making API call now...")
+        response: Message = client.messages.create(**kwargs)
+        print("Debug: API call completed")
+
+        if return_full_response:
+            return response
+        else:
+            # Extract text from the response
+            text_content = ""
+            for content in response.content:
+                if isinstance(content, TextBlock):
+                    text_content += content.text
+            return text_content.strip()
+
+    except Exception as e:
+        error_message = f"Error in Claude API call: {str(e)}"
+        if return_full_response:
+            return {"error": error_message}
+        else:
+            return error_message
+
+
+def get_OAI_response(messages, model="gpt-3.5-turbo", temperature=1.0, max_tokens=64, seed=1331, return_full_response=False):
     try:
         if model != "gpt-4-vision-preview":
-            return get_api_response(messages, model, temperature, max_tokens, seed, return_full_response)
+            return get_OAI_text_response(messages, model, temperature, max_tokens, seed, return_full_response)
         else:
             return get_api_vision_response(messages, model, temperature, max_tokens, seed, return_full_response)
     except Exception: # all retries failed
@@ -73,6 +143,25 @@ def get_response(messages, model="gpt-3.5-turbo", temperature=1.0, max_tokens=64
         else:
             return "Brain disconnect, sorry mate."
         
+
+
+def get_OAI_text_response(messages, model="gpt-3.5-turbo", temperature=1.0, max_tokens=64, seed=1331, return_full_response=False):
+    try:
+        full_response = client.chat.completions.create(
+            model=model,
+            temperature=temperature,
+            messages=messages,
+            max_tokens=max_tokens
+        )
+        if return_full_response:
+            return full_response # the full response object
+        else:
+            return full_response.choices[0].message.content # just the generated text
+    except Exception as e:
+        print(f"(API error: {e}, retrying...)")
+        raise e
+
+
 headers = {
   "Content-Type": "application/json",
   "Authorization": f"Bearer {openai.api_key}"

--- a/utils.py
+++ b/utils.py
@@ -81,12 +81,12 @@ def get_Claude_response(messages, model="claude-3-sonnet-20240229", temperature=
             if role == 'system':
                 if isinstance(content, str):
                     system_messages.append(content)
-                    print(f"Debug: Found text-based system message {idx+1}: {content[:50]}...")
+                    #print(f"Debug: Found text-based system message {idx+1}: {content[:50]}...")
                 else:
                     print(f"Debug: Skipping non-text system message {idx+1}: {type(content)}")
             else:
                 api_messages.append({"role": role, "content": content})
-                print(f"Debug: Added {role} message {idx+1} to API messages")
+                #print(f"Debug: Added {role} message {idx+1} to API messages")
 
         if model == "gpt-4-vision-preview": model = "claude-3-sonnet-20240229"
         kwargs = {

--- a/videochat.py
+++ b/videochat.py
@@ -43,7 +43,7 @@ if __name__ == "__main__":
             os.makedirs(directory)
 
         # Save pre-chat survey emotions to a file
-        with open(f'{directory}/pre_chat_emotions.json_{start_time_str}', 'w') as f:
+        with open(f'{directory}/pre_chat_emotions_{start_time_str}.json', 'w') as f:
             json.dump(pre_survey_emotions, f)
 
         snapshot_path = "snapshot"  # snapshots of camera frames sent to OpenAI are written here
@@ -66,7 +66,7 @@ if __name__ == "__main__":
                           chat_timestamps, new_chat_event, end_session_event)
 
         pipeline = Emolog(start_time, [args.offset, args.offset],
-                          f'{directory}/Emili_raw_{start_time_str}')  # video processing pipeline
+                          f'{directory}/Emili_raw_{start_time_str}.txt')  # video processing pipeline
         user_id = 100000  # set your user ID here
 
         tick_thread = threading.Thread(target=tick)
@@ -125,14 +125,14 @@ if __name__ == "__main__":
         post_survey_emotions = create_emotion_survey(title="Post-Chat Emotion Survey")
         if post_survey_emotions is not None:
             # Save post-chat survey emotions to a file
-            with open(f'{directory}/post_chat_emotions.json_{start_time_str}', 'w') as f:
+            with open(f'{directory}/post_chat_emotions_{start_time_str}.json', 'w') as f:
                 json.dump(post_survey_emotions, f)
 
             # Show the Chat Evaluation Form
             chat_evaluation = create_chat_evaluation()
             if chat_evaluation is not None:
                 # Save chat evaluation to a file
-                with open(f'{directory}/chat_evaluation.json_{start_time_str}', 'w') as f:
+                with open(f'{directory}/chat_evaluation_{start_time_str}.json', 'w') as f:
                     json.dump(chat_evaluation, f)
 
         #   timer_thread.join()

--- a/videochat.py
+++ b/videochat.py
@@ -26,7 +26,7 @@ if __name__ == "__main__":
     if pre_survey_emotions is not None:
 
         # Initialize model parameters and paths
-        model_name = "gpt-4-0125-preview"  # start with a good model
+        model_name = "claude-3-sonnet-20240229"  # start with a good model
         vision_model_name = "gpt-4-vision-preview"  # can this take regular text inputs too?
         secondary_model_name = "gpt-3.5-turbo-0125"  # switch to a cheaper model if the conversation gets too long
         max_context_length = 16000
@@ -75,11 +75,14 @@ if __name__ == "__main__":
         EMA_thread = threading.Thread(target=EMA_thread, args=(start_time, snapshot_path, pipeline), daemon=True)
         EMA_thread.start()
 
+        use_anthropic = True  # use anthropic API for emotion detection
+        print(f"Anthropic value: {use_anthropic}")  # Add this line
         sender_thread = threading.Thread(
             target=sender_thread,
             args=(model_name, vision_model_name, secondary_model_name, max_context_length, gui_app, transcript_path,
-                  start_time_str, start_time),
+                start_time_str, start_time, use_anthropic),
             daemon=True)
+        
         sender_thread.start()
 
         assembler_thread = threading.Thread(target=assembler_thread,


### PR DESCRIPTION
- To preserve the option to switch between OAI and Claude I added an extra argument to the sender thread function: `use_anthropic: Bool`

- broke down the `ge_response()` function into two separate response functions: `get_Claude_response()` and `get_OAI_response()`

- had to rename the vision model function to `get_api_vision_response()`

- due to time and complexity constraints, it was not possible to fully take out vision functionality and make it into a separate module (to preserve it for possible future re-adaptation. hence for the time being `get_Claude_response()` manually discards visual inputs. 

- needed to revise the instructions prompt since Claude appeared to have a harder time following system messages 

- Some parts of the OAI implementation still needs to be updated to work with the existing structure (future to do) 

